### PR TITLE
added handling for invalid urls

### DIFF
--- a/dj_mongohq_url.py
+++ b/dj_mongohq_url.py
@@ -37,6 +37,9 @@ def parse(url):
 
     config = {}
 
+    if not isinstance(url, basestring):
+        url = ''
+
     url = urlparse.urlparse(url)
 
     # Remove query strings.

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,8 @@ from setuptools import setup
 
 setup(
     name='dj-mongohq-url',
-    version='0.0.1',
-    url='https://github.com/ferrix/dj-mongohq-url',
+    version='0.0.2',
+    url='https://github.com/dabido/dj-mongohq-url',
     license='BSD',
     author='Ferrix Hovi',
     author_email='ferrix+github@ferrix.fi',

--- a/test_dj_mongohq_url.py
+++ b/test_dj_mongohq_url.py
@@ -26,6 +26,39 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['PASSWORD'] == 'wegauwhgeuioweg'
         assert url['PORT'] == 10031
 
+    def test_empty_string_parsing(self):
+        url = ''
+        url = dj_mongohq_url.parse(url)
+
+        try:
+            url['ENGINE'] == None
+            assert False
+        except KeyError:
+            assert True
+
+        assert url['NAME'] == ''
+        assert url['HOST'] == None
+        assert url['USER'] == None
+        assert url['PASSWORD'] == None
+        assert url['PORT'] == None
+
+    def test_invalid_type_parsing(self):
+        urls = [None, 123, {0: 1}, [1, 2, 3]]
+
+        for url in urls:
+            url = dj_mongohq_url.parse(url)
+
+            try:
+                url['ENGINE'] == None
+                assert False
+            except KeyError:
+                assert True
+
+            assert url['NAME'] == ''
+            assert url['HOST'] == None
+            assert url['USER'] == None
+            assert url['PASSWORD'] == None
+            assert url['PORT'] == None
 
     def test_mongodb_url(self):
         a = dj_mongohq_url.config()
@@ -41,9 +74,6 @@ class DatabaseTestSuite(unittest.TestCase):
         assert url['USER'] == 'heroku'
         assert url['PASSWORD'] == 'wegauwhgeuioweg'
         assert url['PORT'] == 10031
-
-
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hello

since handling for invalid URLs was missing, it was hard to use a settings.py <-> settings_dev.py setup for development as the tool was quitting with a exception.

Added a very simple check if the inputed value is a string, and if not, convert to a empty string. 
